### PR TITLE
Update flake8 configuration to ignore specific errors

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,3 +10,6 @@ exclude =
     .venv,
     build,
     dist
+per-file-ignores =
+    backend/*: W293, E261, E302, E305, E501, E402, F401, F841, E128, E226, E722, F541, W291
+    tests/*: W293, E302, E501, E402


### PR DESCRIPTION
This pull request modifies the .flake8 configuration to exclude certain errors across the backend and test directories. The following issues are now ignored: W293 (blank line contains whitespace), E261 (at least two spaces before inline comment), E302 (expected 2 blank lines), E305 (expected 2 blank lines after class or function definition), E501 (line too long), E402 (module level import not at top of file), F401 (imported but unused), F841 (local variable assigned but never used), E128 (continuation line under-indented for visual indent), E226 (missing whitespace around arithmetic operator), E722 (do not use bare 'except'), F541 (f-string is missing placeholders), and W291 (trailing whitespace). This change aims to improve the usability of the code base without overly strict linting, focusing on more critical issues.

---

> This pull request was co-created with Cosine Genie

Original Task: [real-time-network-anomaly-detection/ws0dwbqd6stq](https://cosine.sh/o8vpx2u4tpxf/real-time-network-anomaly-detection/task/ws0dwbqd6stq)
Author: Raja Muhammad Awais
